### PR TITLE
allowed user to logout offline

### DIFF
--- a/app/src/main/java/com/marsool/firetool/NoInternet.java
+++ b/app/src/main/java/com/marsool/firetool/NoInternet.java
@@ -15,30 +15,32 @@ public class NoInternet extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.no_internet);
-        Settings.st=false;
+        Settings.st = false;
 
-        findViewById(R.id.reconnect).setOnClickListener(e-> {
+        findViewById(R.id.reconnect).setOnClickListener(e -> {
             Loading recon = new Loading(this);
             recon.setTitle("Reconnect");
             recon.setMessage("Trying to reconnect");
             recon.show(findViewById(R.id.root));
 
-            ConnectivityCheck check = new ConnectivityCheck(this,p->{},
-                    ()-> runOnUiThread(()-> {
+            ConnectivityCheck check = new ConnectivityCheck(this, p -> {
+            },
+                    () -> {
                         Intent intent = new Intent(NoInternet.this, MainActivity.class);
                         startActivity(intent);
-                    }),
-                    ()-> runOnUiThread(()-> {
+                    },
+                    () -> {
                         recon.hide();
                         Alert failed = new Alert(NoInternet.this, AlertType.INFORMATION);
                         failed.setTitle("Reconnect");
                         failed.setMessage("You're not connected!");
                         failed.showAndWait(findViewById(R.id.root), r -> {
                         });
-                    }));
+                    });
             check.execute();
         });
     }
+
     public void onBackPressed() {
         finish();
         startActivity(getIntent());

--- a/app/src/main/java/com/marsool/firetool/Settings.java
+++ b/app/src/main/java/com/marsool/firetool/Settings.java
@@ -18,6 +18,8 @@ import com.marsool.firetool.ui.alerts.ButtonType;
 
 
 public class Settings extends AppCompatActivity {
+    static private final String sharedPrefName = "firetoolapp";
+
     public static Boolean a;
     public static Boolean b;
     public static Boolean c;
@@ -30,7 +32,7 @@ public class Settings extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.settings);
-        SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+        SharedPreferences pref = getApplicationContext().getSharedPreferences(sharedPrefName, 0); // 0 - for private mode
         spm = SharedPrefManager.getInstance(this);
         TextView contact = findViewById(R.id.contact);
         contact.setOnClickListener(v -> {
@@ -94,7 +96,7 @@ public class Settings extends AppCompatActivity {
 
         final Switch update = (Switch) findViewById(R.id.switch1);
         update.setOnClickListener(v -> {
-            SharedPreferences pref1 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences pref1 = getApplicationContext().getSharedPreferences(sharedPrefName, 0); // 0 - for private mode
             SharedPreferences.Editor editor = pref1.edit();
             editor.putBoolean("a", update.isChecked());
             editor.commit();
@@ -102,7 +104,7 @@ public class Settings extends AppCompatActivity {
         });
         final Switch skip = (Switch) findViewById(R.id.switch2);
         skip.setOnClickListener(v -> {
-            SharedPreferences pref14 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences pref14 = getApplicationContext().getSharedPreferences(sharedPrefName, 0); // 0 - for private mode
             SharedPreferences.Editor editor = pref14.edit();
             editor.putBoolean("b", skip.isChecked());
             editor.commit();
@@ -115,14 +117,14 @@ public class Settings extends AppCompatActivity {
 
         final Switch send = (Switch) findViewById(R.id.switch5);
         send.setOnClickListener(v -> {
-            SharedPreferences pref13 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences pref13 = getApplicationContext().getSharedPreferences(sharedPrefName, 0); // 0 - for private mode
             SharedPreferences.Editor editor = pref13.edit();
             editor.putBoolean("d", send.isChecked());
             editor.commit();
             d = pref13.getBoolean("d", true);
         });
         write.setOnClickListener(v -> {
-            SharedPreferences pref12 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences pref12 = getApplicationContext().getSharedPreferences(sharedPrefName, 0); // 0 - for private mode
             SharedPreferences.Editor editor = pref12.edit();
             editor.putBoolean("c", write.isChecked());
             if (!write.isChecked()) {

--- a/app/src/main/java/com/marsool/firetool/Settings.java
+++ b/app/src/main/java/com/marsool/firetool/Settings.java
@@ -3,8 +3,6 @@ package com.marsool.firetool;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.Button;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -24,10 +22,8 @@ public class Settings extends AppCompatActivity {
     public static Boolean b;
     public static Boolean c;
     public static Boolean d;
-    Button contact, out;
     public static boolean st = true;
 
-    private String token;
     private SharedPrefManager spm;
 
 
@@ -37,20 +33,14 @@ public class Settings extends AppCompatActivity {
         SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
         spm = SharedPrefManager.getInstance(this);
         TextView contact = findViewById(R.id.contact);
-        contact.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(getApplicationContext(), Contact.class);
-                startActivity(intent);
-            }
+        contact.setOnClickListener(v -> {
+            Intent intent = new Intent(getApplicationContext(), Contact.class);
+            startActivity(intent);
         });
         contact = findViewById(R.id.contact);
-        contact.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(getApplicationContext(), Contact.class);
-                startActivity(intent);
-            }
+        contact.setOnClickListener(v -> {
+            Intent intent = new Intent(getApplicationContext(), Contact.class);
+            startActivity(intent);
         });
         TextView out = findViewById(R.id.logout);
         out.setOnClickListener(e -> {
@@ -75,7 +65,16 @@ public class Settings extends AppCompatActivity {
 
                                 @Override
                                 public void handleError(Exception x) {
-
+                                    //STORE PENDING LOGOUT
+                                    runOnUiThread(()-> {
+                                        loading.hide();
+                                        SharedPrefManager.getInstance(Settings.this).storePendingLogout();
+                                        Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+                                        Bundle b = new Bundle();
+                                        b.putBoolean("skip_connect",true);
+                                        intent.putExtras(b);
+                                        startActivity(intent);
+                                    });
                                 }
                             });
                     logout.addHeader("Authorization", "Bearer " + spm.getToken());
@@ -90,36 +89,24 @@ public class Settings extends AppCompatActivity {
             start.setChecked(false);
         } else {
             start.setClickable(true);
-
-            start.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    st = !st;
-                }
-            });
+            start.setOnClickListener(v -> st = !st);
         }
 
         final Switch update = (Switch) findViewById(R.id.switch1);
-        update.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
-                SharedPreferences.Editor editor = pref.edit();
-                editor.putBoolean("a", update.isChecked());
-                editor.commit();
+        update.setOnClickListener(v -> {
+            SharedPreferences pref1 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences.Editor editor = pref1.edit();
+            editor.putBoolean("a", update.isChecked());
+            editor.commit();
 
-            }
         });
         final Switch skip = (Switch) findViewById(R.id.switch2);
-        skip.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
-                SharedPreferences.Editor editor = pref.edit();
-                editor.putBoolean("b", skip.isChecked());
-                editor.commit();
-                b = pref.getBoolean("b", true);
-            }
+        skip.setOnClickListener(v -> {
+            SharedPreferences pref14 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences.Editor editor = pref14.edit();
+            editor.putBoolean("b", skip.isChecked());
+            editor.commit();
+            b = pref14.getBoolean("b", true);
         });
         Switch skip2 = (Switch) findViewById(R.id.switch3);
         skip2.setClickable(false);
@@ -127,33 +114,27 @@ public class Settings extends AppCompatActivity {
         final Switch write = (Switch) findViewById(R.id.switch4);
 
         final Switch send = (Switch) findViewById(R.id.switch5);
-        send.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
-                SharedPreferences.Editor editor = pref.edit();
-                editor.putBoolean("d", send.isChecked());
-                editor.commit();
-                d = pref.getBoolean("d", true);
-            }
+        send.setOnClickListener(v -> {
+            SharedPreferences pref13 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences.Editor editor = pref13.edit();
+            editor.putBoolean("d", send.isChecked());
+            editor.commit();
+            d = pref13.getBoolean("d", true);
         });
-        write.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                SharedPreferences pref = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
-                SharedPreferences.Editor editor = pref.edit();
-                editor.putBoolean("c", write.isChecked());
-                if (!write.isChecked()) {
-                    editor.putBoolean("d", false);
-                    send.setClickable(false);
-                    send.setChecked(false);
-                } else {
-                    send.setClickable(true);
+        write.setOnClickListener(v -> {
+            SharedPreferences pref12 = getApplicationContext().getSharedPreferences("MyPref", 0); // 0 - for private mode
+            SharedPreferences.Editor editor = pref12.edit();
+            editor.putBoolean("c", write.isChecked());
+            if (!write.isChecked()) {
+                editor.putBoolean("d", false);
+                send.setClickable(false);
+                send.setChecked(false);
+            } else {
+                send.setClickable(true);
 
-                }
-                editor.commit();
-                c = pref.getBoolean("c", true);
             }
+            editor.commit();
+            c = pref12.getBoolean("c", true);
         });
         a = pref.getBoolean("a", true);
         b = pref.getBoolean("b", true);

--- a/app/src/main/java/com/marsool/firetool/SharedPrefManager.java
+++ b/app/src/main/java/com/marsool/firetool/SharedPrefManager.java
@@ -15,6 +15,7 @@ public class SharedPrefManager {
     //the constants
     private static final String SHARED_PREF_NAME = "marsool.firetool.sharedPref";
     private static final String KEY_TOKEN = "user_token";
+    private static final String PENDING_LOGOUT = "pending_logout";
 
     private static SharedPrefManager mInstance;
     private static Context mCtx;
@@ -31,12 +32,36 @@ public class SharedPrefManager {
     }
 
     //method to let the user login
-    //this method will store the user data in shared preferences
+    //this method will store the user token in shared preferences
     public void storeToken(String token) {
         SharedPreferences sharedPreferences = mCtx.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(KEY_TOKEN, token);
         editor.apply();
+    }
+
+    //method to let the user logout when he's offline
+    //this method will store the user token in shared preferences to revoke it when the phone is connected
+    public void storePendingLogout() {
+        SharedPreferences sharedPreferences = mCtx.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString(PENDING_LOGOUT, getToken());
+        editor.remove(KEY_TOKEN);
+        editor.apply();
+    }
+
+    //delete pending logout token after it was revoked from the server
+    public void deletePendingLogout() {
+        SharedPreferences sharedPreferences = mCtx.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.remove(PENDING_LOGOUT);
+        editor.apply();
+    }
+
+    //get token that is pending logout (if present)
+    public String getPendingLogout() {
+        SharedPreferences sharedPreferences = mCtx.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        return sharedPreferences.getString(PENDING_LOGOUT, null);
     }
 
     //this method will checker whether user is already logged in or not


### PR DESCRIPTION
user triggered logout api calls will handle connectivity errors as follows : 

- storing the token as pending_logout
- another logout api call will be automatically triggered at the next successful connectivity check
- if the logout succeeds the token gets deleted